### PR TITLE
Feature/#4 - 상품 및 상품이미지 등록 로직 구현

### DIFF
--- a/Modulesson/src/main/java/com/jditeam2/modulesson/controller/ItemController.java
+++ b/Modulesson/src/main/java/com/jditeam2/modulesson/controller/ItemController.java
@@ -1,0 +1,16 @@
+package com.jditeam2.modulesson.controller;
+
+import com.jditeam2.modulesson.dto.ItemForm;
+import org.h2.engine.Mode;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class ItemController {
+    @GetMapping(value = "expert/item/new")
+    public String itemForm(Model model) {
+        model.addAttribute("itemForm", new ItemForm());
+        return "item/itemForm";
+    }
+}

--- a/Modulesson/src/main/java/com/jditeam2/modulesson/domain/Item.java
+++ b/Modulesson/src/main/java/com/jditeam2/modulesson/domain/Item.java
@@ -1,0 +1,59 @@
+package com.jditeam2.modulesson.domain;
+
+import com.jditeam2.modulesson.exception.OutOfStockException;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.*;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@Entity
+public class Item extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "item_id")
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String itemName;
+
+    @Column(name = "price", nullable = false)
+    private int price;
+
+    @Column(nullable = false)
+    private int stockNumber;
+
+    @Lob
+    @Column(nullable = false)
+    private String itemDetail;
+
+    @Enumerated(EnumType.STRING)
+    private ItemSellStatus itemSellStatus;
+
+    @Builder
+    public Item(String itemName, int price, int stockNumber, String itemDetail, ItemSellStatus itemSellStatus) {
+        this.itemName = itemName;
+        this.price = price;
+        this.stockNumber = stockNumber;
+        this.itemDetail = itemDetail;
+        this.itemSellStatus = itemSellStatus;
+    }
+
+    public void addStock(int stockNumber) {
+        this.stockNumber += stockNumber;
+    }
+    public void removeStock(int stockNumber) {
+        int restStock = this.stockNumber - stockNumber;
+        if (restStock < 0) {
+            throw new OutOfStockException("상품의 재고가 부족합니다.(현재 재고 수량: " + this.stockNumber + ")");
+        }
+        this.stockNumber = restStock;
+    }
+
+
+}

--- a/Modulesson/src/main/java/com/jditeam2/modulesson/domain/ItemImg.java
+++ b/Modulesson/src/main/java/com/jditeam2/modulesson/domain/ItemImg.java
@@ -1,0 +1,45 @@
+package com.jditeam2.modulesson.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.*;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@Table(name = "item_img")
+@Entity
+public class ItemImg {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "item_img_id")
+    private Long id;
+
+    private String imgName;
+    private String originalImgName;
+    private String imgUrl;
+    private String repImgYn;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id")
+    private Item item;
+
+    @Builder
+    public ItemImg(String imgName, String originalImgName, String imgUrl, String repImgYn, Item item) {
+        this.imgName = imgName;
+        this.originalImgName = originalImgName;
+        this.imgUrl = imgUrl;
+        this.repImgYn = repImgYn;
+        this.item = item;
+    }
+
+    public void updateItemImg(String originalImgName, String imgName, String imgUrl) {
+        this.originalImgName = originalImgName;
+        this.imgName = imgName;
+        this.imgUrl = imgUrl;
+    }
+}

--- a/Modulesson/src/main/java/com/jditeam2/modulesson/dto/ItemForm.java
+++ b/Modulesson/src/main/java/com/jditeam2/modulesson/dto/ItemForm.java
@@ -1,0 +1,64 @@
+package com.jditeam2.modulesson.dto;
+
+import com.jditeam2.modulesson.domain.Item;
+import com.jditeam2.modulesson.domain.ItemSellStatus;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class ItemForm {
+    private Long id;
+
+    @NotBlank
+    private String itemName;
+
+    @NotNull
+    private Integer price;
+
+    private String itemDetail;
+
+    @NotNull
+    private Integer stockNumber;
+
+    private ItemSellStatus itemSellStatus;
+
+    private List<ItemImgDto> itemImgDtoList = new ArrayList<>();
+
+    private List<Long> itemImgIds = new ArrayList<>();
+
+    @Builder
+    public ItemForm(String itemName, Integer price, String itemDetail, Integer stockNumber, ItemSellStatus itemSellStatus) {
+        this.itemName = itemName;
+        this.price = price;
+        this.itemDetail = itemDetail;
+        this.stockNumber = stockNumber;
+        this.itemSellStatus = itemSellStatus;
+    }
+
+    public Item toEntity(ItemForm form) {
+        Item entity = Item.builder()
+                .itemName(form.itemName)
+                .itemDetail(form.itemDetail)
+                .stockNumber(form.stockNumber)
+                .itemSellStatus(form.itemSellStatus)
+                .build();
+        return entity;
+    }
+
+    public ItemForm of(Item entity) {
+        ItemForm form = ItemForm.builder()
+                .itemName(entity.getItemName())
+                .itemDetail(entity.getItemDetail())
+                .stockNumber(entity.getStockNumber())
+                .itemSellStatus(entity.getItemSellStatus())
+                .build();
+        return form;
+    }
+}

--- a/Modulesson/src/main/java/com/jditeam2/modulesson/dto/ItemImgDto.java
+++ b/Modulesson/src/main/java/com/jditeam2/modulesson/dto/ItemImgDto.java
@@ -1,0 +1,46 @@
+package com.jditeam2.modulesson.dto;
+
+
+import com.jditeam2.modulesson.domain.ItemImg;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor
+public class ItemImgDto {
+    private Long id;
+
+    private String imgName;
+    private String originalImgName;
+    private String imgUrl;
+    private String repImgYn;
+
+    @Builder
+    public ItemImgDto(String imgName, String originalImgName, String imgUrl, String repImgYn) {
+        this.imgName = imgName;
+        this.originalImgName = originalImgName;
+        this.imgUrl = imgUrl;
+        this.repImgYn = repImgYn;
+    }
+
+    public ItemImg toEntity(ItemImgDto dto) {
+        ItemImg entity = ItemImg.builder()
+                .imgName(dto.getImgName())
+                .originalImgName(dto.originalImgName)
+                .imgUrl(dto.imgUrl)
+                .repImgYn(dto.repImgYn)
+                .build();
+        return entity;
+    }
+
+    public ItemImgDto of(ItemImg entity) {
+        ItemImgDto dto = ItemImgDto.builder()
+                .imgName(entity.getImgName())
+                .originalImgName(entity.getOriginalImgName())
+                .imgUrl(entity.getImgUrl())
+                .repImgYn(entity.getRepImgYn())
+                .build();
+        return dto;
+    }
+}

--- a/Modulesson/src/main/java/com/jditeam2/modulesson/repository/ItemImgRepository.java
+++ b/Modulesson/src/main/java/com/jditeam2/modulesson/repository/ItemImgRepository.java
@@ -1,0 +1,13 @@
+package com.jditeam2.modulesson.repository;
+
+import com.jditeam2.modulesson.domain.ItemImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+public interface ItemImgRepository extends JpaRepository<ItemImg, Long> {
+    List<ItemImg> findByItemIdOrderByIdAsc(Long itemId);
+
+    ItemImg findByItemIdAndRepImgYn(Long itemId, String repImgYn);
+}

--- a/Modulesson/src/main/java/com/jditeam2/modulesson/repository/ItemRepository.java
+++ b/Modulesson/src/main/java/com/jditeam2/modulesson/repository/ItemRepository.java
@@ -1,0 +1,8 @@
+package com.jditeam2.modulesson.repository;
+
+import com.jditeam2.modulesson.domain.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+}

--- a/Modulesson/src/main/resources/application.yml
+++ b/Modulesson/src/main/resources/application.yml
@@ -18,4 +18,9 @@ spring:
         show_sql: true
     defer-datasource-initialization: true
     database-platform: org.hibernate.dialect.H2Dialect
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 100MB
+
 

--- a/Modulesson/src/main/resources/application.yml
+++ b/Modulesson/src/main/resources/application.yml
@@ -7,11 +7,11 @@ spring:
     url: jdbc:h2:mem:testdb
     driverClassName: org.h2.Driver
     username: sa
-    password:
+    password: password
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
상품명, 가격, 재고, 상품디테일, 판매상태 추가,
enum 클래스 사용 하여 판매상태 관리,

Entity 어노테이션으로 클래스를 엔티티로 선언
각 상품아이디에 테이블의 기존키로 사용할 속성 지정,
GeneratedValue 전략으로 JPA 구현체가 자동으로 생성 전략 결정

ItemRepository 인터페이스에 JpaRepository 상속

상품 등록 및 수정에 사용할 데이터 전달용 Dto생성

상품등록 itemForm 컨트롤러 생성(전문가만 상품등록 할 수 있도록 전문가 페이지만 연결)

애플리케이션 실행 시 테이블 다시 만들지 않기 위해 application.yml 파일 내 ddl-auto 속성을 validate로 변경

validate로 설정 시 애플리케이션 실행 시점에 테이블을 삭제한 후 재생성 하지 않고 엔티티와 테이블의 매핑 확인만 진행

기존 상품 저장, 등록 엔티티와 동일한 구조로 이미지 등록 엔티티 생성

application.yml 내 상품 이미지 업로드 jpa servlet FileSize & RequestSize 설정

이미지 업로드 로케이션은 추후 설정

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
